### PR TITLE
[Feat] 과일 추천 - 카테고리 연결

### DIFF
--- a/Gwayeon/Controllers/FruitRecommend/FruitSelectViewController.swift
+++ b/Gwayeon/Controllers/FruitRecommend/FruitSelectViewController.swift
@@ -25,6 +25,8 @@ class FruitSelectViewController: UIViewController {
         return collectionView
     }()
     
+    var getSelectedItem: ((_ item: String) -> Void)?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureCollectionView()
@@ -78,5 +80,9 @@ extension FruitSelectViewController: UICollectionViewDelegateFlowLayout, UIColle
         let cellWidth = (collectionViewWidth - 32 * 3)/4
         let cellHeight = (collectionViewHeight - 24 * 4)/5
         return CGSize(width: cellWidth, height: cellHeight)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.getSelectedItem?(categoryArray[indexPath.item])
     }
 }

--- a/Gwayeon/Controllers/FruitRecommend/FruitSelectViewController.swift
+++ b/Gwayeon/Controllers/FruitRecommend/FruitSelectViewController.swift
@@ -6,11 +6,12 @@
 //
 
 import UIKit
+class FruitCategory {
+    static let names = ["사과", "배", "귤", "수박", "포도", "복숭아", "토마토", "자두", "블루베리", "딸기", "참외", "멜론", "키위", "무화과", "망고", "감", "기타 과일"]
+    static let images = ["apple", "pear", "tangerine", "watermelon", "grape", "peach-1", "tomato", "plum", "blueberry", "strawberry", "korean_melon", "melon", "kiwi", "fig", "mango", "persimmon", "other"]
+}
 
 class FruitSelectViewController: UIViewController {
-    private let categoryArray = ["사과", "배", "귤", "수박", "포도", "복숭아", "토마토", "자두", "블루베리", "딸기", "참외", "멜론", "키위", "무화과", "망고", "감", "기타 과일"]
-    private let categoryImage = ["apple", "pear", "tangerine", "watermelon", "grape", "peach-1", "tomato", "plum", "blueberry", "strawberry", "korean_melon", "melon", "kiwi", "fig", "mango", "persimmon", "other"]
-    
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "과일 선택"
@@ -25,7 +26,7 @@ class FruitSelectViewController: UIViewController {
         return collectionView
     }()
     
-    var getSelectedItem: ((_ item: String) -> Void)?
+    var getSelectedItem: ((_ item: Int) -> Void)?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -64,8 +65,8 @@ extension FruitSelectViewController: UICollectionViewDelegateFlowLayout, UIColle
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cellText = categoryArray[indexPath.item]
-        let cellImage = categoryImage[indexPath.item]
+        let cellText = FruitCategory.names[indexPath.item]
+        let cellImage = FruitCategory.images[indexPath.item]
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FruitSelectCollectionViewCell.identifier, for: indexPath) as? FruitSelectCollectionViewCell else {
             return UICollectionViewCell()
         }
@@ -83,6 +84,6 @@ extension FruitSelectViewController: UICollectionViewDelegateFlowLayout, UIColle
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.getSelectedItem?(categoryArray[indexPath.item])
+        self.getSelectedItem?(indexPath.item)
     }
 }

--- a/Gwayeon/Controllers/FruitRecommend/FruitSelectViewController.swift
+++ b/Gwayeon/Controllers/FruitRecommend/FruitSelectViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+// TODO: - Globals 폴더로 이동
 class FruitCategory {
     static let names = ["사과", "배", "귤", "수박", "포도", "복숭아", "토마토", "자두", "블루베리", "딸기", "참외", "멜론", "키위", "무화과", "망고", "감", "기타 과일"]
     static let images = ["apple", "pear", "tangerine", "watermelon", "grape", "peach-1", "tomato", "plum", "blueberry", "strawberry", "korean_melon", "melon", "kiwi", "fig", "mango", "persimmon", "other"]
@@ -70,8 +71,7 @@ extension FruitSelectViewController: UICollectionViewDelegateFlowLayout, UIColle
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FruitSelectCollectionViewCell.identifier, for: indexPath) as? FruitSelectCollectionViewCell else {
             return UICollectionViewCell()
         }
-        cell.label.text = cellText
-        cell.fruitImage.image = UIImage(named: cellImage)
+        cell.configure(text: cellText, image: cellImage)
         return cell
     }
     

--- a/Gwayeon/Controllers/FruitRecommend/View/FruitSelectCollectionViewCell.swift
+++ b/Gwayeon/Controllers/FruitRecommend/View/FruitSelectCollectionViewCell.swift
@@ -10,14 +10,14 @@ import UIKit
 class FruitSelectCollectionViewCell: UICollectionViewCell {
     static let identifier = "FruitSelectCollectionViewCell"
 
-    let fruitImage: UIImageView = {
+    private lazy var fruitImage: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.clipsToBounds = true
         return imageView
     }()
 
-    let label: UILabel = {
+    private lazy var label: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 17)
         return label
@@ -49,6 +49,11 @@ class FruitSelectCollectionViewCell: UICollectionViewCell {
             NSLayoutConstraint.activate(constraint)
         }
 
+    }
+    
+    func configure(text: String, image: String) {
+        label.text = text
+        fruitImage.image = UIImage(named: image)
     }
     
 }

--- a/Gwayeon/Globals/Extension/UIView+Extension.swift
+++ b/Gwayeon/Globals/Extension/UIView+Extension.swift
@@ -7,10 +7,18 @@
 import UIKit
 
 extension UIView {
-  func addSubviews(_ views: UIView...) {
-    for view in views {
-      view.translatesAutoresizingMaskIntoConstraints = false
-      self.addSubview(view)
+    func addSubviews(_ views: UIView...) {
+        for view in views {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview(view)
+        }
     }
-  }
+}
+
+extension UIStackView {
+    func addArrangedSubviews(_ views: UIView...) {
+        for view in views {
+            self.addArrangedSubview(view)
+        }
+    }
 }

--- a/Gwayeon/InputSection.swift
+++ b/Gwayeon/InputSection.swift
@@ -106,6 +106,10 @@ final class InputSection: UIStackView {
             textView.heightAnchor.constraint(equalToConstant: 130).isActive = true
         }
     }
+    
+    func setTextFieldItem(_ item: String) {
+        textField.attributedPlaceholder = NSAttributedString(string: item, attributes: [.foregroundColor: UIColor.black])
+    }
 }
 
 extension InputSection {

--- a/Gwayeon/RecommendFarmViewController.swift
+++ b/Gwayeon/RecommendFarmViewController.swift
@@ -95,7 +95,7 @@ class RecommendFarmViewController: UIViewController {
         let modalViewController = FruitSelectViewController()
         modalViewController.modalPresentationStyle = .pageSheet
         modalViewController.getSelectedItem = { item in
-            self.categorySection.setTextFieldItem(item)
+            self.categorySection.setTextFieldItem(FruitCategory.names[item])
             modalViewController.dismiss(animated: true)
         }
         present(modalViewController, animated: true, completion: nil)

--- a/Gwayeon/RecommendFarmViewController.swift
+++ b/Gwayeon/RecommendFarmViewController.swift
@@ -12,8 +12,6 @@ class RecommendFarmViewController: UIViewController {
         let titleLabel = UILabel()
         titleLabel.text = "농장 추천하기"
         titleLabel.font = UIFont.boldSystemFont(ofSize: 22)
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        
         return titleLabel
     }()
     private lazy var categorySection = InputSection(frame: .zero, style: .fruitCategory)
@@ -26,15 +24,7 @@ class RecommendFarmViewController: UIViewController {
         stackView.axis = .vertical
         stackView.spacing = 30
         stackView.alignment = .fill
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        
-        // TODO: addArrangedSubviews Extension으로 작성
-        stackView.addArrangedSubview(categorySection)
-        stackView.addArrangedSubview(varietySection)
-        stackView.addArrangedSubview(farmNameSection)
-        stackView.addArrangedSubview(farmNumberSection)
-        stackView.addArrangedSubview(recommendationSection)
-        
+        stackView.addArrangedSubviews(categorySection, varietySection, farmNameSection, farmNumberSection, recommendationSection)
         return stackView
     }()
     
@@ -43,7 +33,7 @@ class RecommendFarmViewController: UIViewController {
         button.setTitle("완료", for: .normal)
         button.backgroundColor = UIColor(red: 246/255, green: 104/255, blue: 94/255, alpha: 1)
         button.layer.cornerRadius = 13
-        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isEnabled = false
         button.addTarget(nil, action: #selector(completeButtonClicked(_:)), for: .touchUpInside)
         return button
     }()

--- a/Gwayeon/RecommendFarmViewController.swift
+++ b/Gwayeon/RecommendFarmViewController.swift
@@ -86,5 +86,18 @@ class RecommendFarmViewController: UIViewController {
         [titleLabelConstraint, sectionStackViewConstraint, finishButtonConstraint].forEach { constraint in
             NSLayoutConstraint.activate(constraint)
         }
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapCategory))
+        categorySection.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func didTapCategory() {
+        let modalViewController = FruitSelectViewController()
+        modalViewController.modalPresentationStyle = .pageSheet
+        modalViewController.getSelectedItem = { item in
+            self.categorySection.setTextFieldItem(item)
+            modalViewController.dismiss(animated: true)
+        }
+        present(modalViewController, animated: true, completion: nil)
     }
 }

--- a/Gwayeon/RecommendFarmViewController.swift
+++ b/Gwayeon/RecommendFarmViewController.swift
@@ -41,6 +41,7 @@ class RecommendFarmViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setLayout()
+        setGesture()
         hideKeyboardWhenTappedAround()
     }
     
@@ -76,7 +77,9 @@ class RecommendFarmViewController: UIViewController {
         [titleLabelConstraint, sectionStackViewConstraint, finishButtonConstraint].forEach { constraint in
             NSLayoutConstraint.activate(constraint)
         }
-        
+    }
+    
+    private func setGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapCategory))
         categorySection.addGestureRecognizer(tapGesture)
     }


### PR DESCRIPTION
## 🍑 관련 이슈
#85 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🍑 구현/변경 사항 및 이유
- 과일 카테고리를 누르면 과일 선택 시트가 올라옵니다
- 과일을 선택하면 시트가 내려가고 카테고리에 과일 이름이 보입니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🍑 PR Point
- 과일 이름, 이미지 리스트를 스태틱으로 변경했습니다. 추후 폴러링 때 위치 옮길 예정입니다.
- FruitSelectCell의 라벨과 이미지를 private으로 변경하고 설정하는 함수를 만들었습니다.
- 뷰간 데이터 전달은 closure로 전달했습니다.
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🍑 참고 사항
<img src="https://user-images.githubusercontent.com/58019653/181668474-9c6fc716-45c7-4a97-ad64-236d3a966b6d.gif" width="150"/>

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->


