### PR TITLE
[Fix] 온보딩 랜덤과일 선택 오류 해결

### DIFF
--- a/Gwayeon/Controllers/UserProfileCompletionViewController.swift
+++ b/Gwayeon/Controllers/UserProfileCompletionViewController.swift
@@ -14,7 +14,7 @@ class UserProfileCompletionViewController: UIViewController {
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
         let categoryImage = ["apple", "pear", "tangerine", "watermelon", "grape", "peach-1", "tomato", "plum", "blueberry", "strawberry", "korean_melon", "melon", "kiwi", "fig", "mango", "persimmon", "other"]
-        let randomNumber = Int.random(in: 0...categoryImage.count)
+        let randomNumber = Int.random(in: 0...categoryImage.count-1)
         imageView.image = UIImage(named: categoryImage[randomNumber])
         imageView.contentMode = .scaleAspectFit
         imageView.clipsToBounds = true


### PR DESCRIPTION
## 🍑 관련 이슈
#128 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🍑 구현/변경 사항 및 이유
```swift
let categoryImage = ["apple", "pear", "tangerine", "watermelon", "grape", "peach-1", "tomato", "plum", "blueberry", "strawberry", "korean_melon", "melon", "kiwi", "fig", "mango", "persimmon", "other"]
        let randomNumber = Int.random(in: 0...categoryImage.count-1)
        imageView.image = UIImage(named: categoryImage[randomNumber])
```
... 을 잘못 사용하여, 인덱스 범위 오류가 발생하였습니다.
count에서 1을 빼주어 해결!
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🍑 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🍑 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->


