### PR TITLE
[Fix] 과일 추천하기와 상세뷰 네비게이션 시 탭바 숨기기

### DIFF
--- a/Gwayeon/Controllers/EmptyButtonCollectionViewCell.swift
+++ b/Gwayeon/Controllers/EmptyButtonCollectionViewCell.swift
@@ -35,6 +35,7 @@ class EmptyButtonCollectionViewCell: UICollectionViewCell {
     
     @objc private func plusButtonClicked(_ sender: Any) {
         let recommendFarmViewController = RecommendFarmViewController()
+        recommendFarmViewController.hidesBottomBarWhenPushed = true
         recommendFarmViewController.navigationItem.largeTitleDisplayMode = .never
         parent?.navigationController?.pushViewController(recommendFarmViewController, animated: true)
     }

--- a/Gwayeon/Controllers/HomeViewController.swift
+++ b/Gwayeon/Controllers/HomeViewController.swift
@@ -153,6 +153,7 @@ extension HomeViewController: UICollectionViewDataSource {
 extension HomeViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let detailViewController = DetailViewController()
+        detailViewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(detailViewController, animated: true)
     }
 }

--- a/Gwayeon/Controllers/MyPageViewController.swift
+++ b/Gwayeon/Controllers/MyPageViewController.swift
@@ -296,10 +296,12 @@ extension MyPageViewController: UICollectionViewDelegate {
             switch indexPath.row {
             case CollectionViewCellSection.addingFarm.rawValue:
                 let recommendFarmViewController = RecommendFarmViewController()
+                recommendFarmViewController.hidesBottomBarWhenPushed = true
                 recommendFarmViewController.navigationItem.largeTitleDisplayMode = .never
                 self.navigationController?.pushViewController(recommendFarmViewController, animated: true)
             default:
                 let detailViewController = DetailViewController()
+                detailViewController.hidesBottomBarWhenPushed = true
                 detailViewController.navigationItem.largeTitleDisplayMode = .never
                 self.navigationController?.pushViewController(detailViewController, animated: true)
             }


### PR DESCRIPTION
## 🍑 관련 이슈
#154 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🍑 구현/변경 사항 및 이유
- 과일 추천하기 버튼을 눌렀을 때 그리고 상세 페이지 들어갔을 때 탭바를 숨기도록 했습니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🍑 PR Point
탭바를 숨겨야하는 부분이 추가적으로 있다면 알려주세요
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🍑 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
**이전**
<img src="https://user-images.githubusercontent.com/58019653/182098786-6f1364c9-c812-46a9-bd1e-4372e230a664.png" width="150"/> <img src="https://user-images.githubusercontent.com/58019653/182099037-a301ac3c-e08b-40a7-96eb-8a9dee84eacf.png" width="150"/>


**이후**
<img src="https://user-images.githubusercontent.com/58019653/182104118-4615afd9-4cd5-48e1-96bf-ab7462c42e16.png" width="150"/><img src="https://user-images.githubusercontent.com/58019653/182104158-e398be93-0706-4e6e-bd4f-678e4689da79.png" width="150"/>


