### PR TITLE
[FEAT] my page title 폰트 크기 변경, 프로필과 간격 조정

### DIFF
--- a/Gwayeon/Controllers/MyPageViewController.swift
+++ b/Gwayeon/Controllers/MyPageViewController.swift
@@ -215,7 +215,7 @@ extension MyPageViewController {
         }
         
         let myProfileImageViewConstraints = [
-            myProfileImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 40),
+            myProfileImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 15),
             myProfileImageView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
             myProfileImageView.widthAnchor.constraint(equalToConstant: 68),
             myProfileImageView.heightAnchor.constraint(equalToConstant: 68)
@@ -223,7 +223,7 @@ extension MyPageViewController {
         
         let myNameLabelConstraints = [
             myNameLabel.leadingAnchor.constraint(equalTo: myProfileImageView.trailingAnchor, constant: 16),
-            myNameLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 50),
+            myNameLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 25),
             myNameLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -70)
         ]
         
@@ -235,7 +235,7 @@ extension MyPageViewController {
         
         let disclosureButtonConstraints = [
             disclosureButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -26),
-            disclosureButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 57)
+            disclosureButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 35)
         ]
         
         [myProfileImageViewConstraints, myNameLabelConstraints, gwayeonCountLabelConstraints, disclosureButtonConstraints].forEach { constraints in

--- a/Gwayeon/Controllers/MyPageViewController.swift
+++ b/Gwayeon/Controllers/MyPageViewController.swift
@@ -164,7 +164,10 @@ extension MyPageViewController {
         
         self.navigationController?.navigationBar.tintColor = .black
         self.navigationController?.navigationBar.prefersLargeTitles = true
-        self.navigationItem.title = "나의 농장생활"
+        self.navigationItem.title = "나의 농장 생활"
+        self.navigationController?.navigationBar.largeTitleTextAttributes =
+        [NSAttributedString.Key.foregroundColor: UIColor.black,
+         NSAttributedString.Key.font: UIFont.systemFont(ofSize: 28, weight: .bold)]
         self.navigationItem.largeTitleDisplayMode = .always
         guard let navigationBar = self.navigationController?.navigationBar else { return }
         


### PR DESCRIPTION
## 🍑 관련 이슈
#152 

## 🍑 구현/변경 사항 및 이유
- '나의 농장 생활' 폰트 크기를 메인의 title 폰트 크기와 맞춤
- title과 프로필 간격 조정

## 🍑 PR Point
- 메인 title 위치보다 마이페이지 title 위치가 조금 낮은데 navigation bar라 위치를 어떻게 조정해야할지 모르겠습니다..

## 🍑 참고 사항
<img src="https://user-images.githubusercontent.com/37866609/182109293-1fec647c-7bb5-453a-94d4-8468e0ad7281.jpeg" width="200" />


